### PR TITLE
Configurable logs support

### DIFF
--- a/IMACS.yml
+++ b/IMACS.yml
@@ -1,0 +1,2 @@
+logs:
+  location: ""

--- a/radio/app/__init__.py
+++ b/radio/app/__init__.py
@@ -2,11 +2,12 @@ import logging
 import os
 import sys
 from datetime import datetime
-from configparser import ConfigParser
+import yaml
 
 from flask import Flask
 from flask_socketio import SocketIO
 
+CONFIG_FILE = os.path.join(os.getcwd(), "IMACS.yml")
 
 def create_directory(path: str, count: int) -> str:
     """
@@ -30,12 +31,11 @@ def create_directory(path: str, count: int) -> str:
     except OSError:
         return create_directory(path, count + 1)
 
-file = 'imacs.ini'
 
-config = ConfigParser()
-config.read(file)
+with open(CONFIG_FILE, 'r') as file:
+    config = yaml.safe_load(file)
 
-if 'logs' in config.sections() and 'location' in config['logs']:
+if 'logs' in config and config['logs'].get('location'):
     log_dir = config['logs']['location']
 else:
     log_dir = os.path.expanduser("~/.imacs/logs")

--- a/radio/app/__init__.py
+++ b/radio/app/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 from datetime import datetime
+from configparser import ConfigParser
 
 from flask import Flask
 from flask_socketio import SocketIO
@@ -29,12 +30,15 @@ def create_directory(path: str, count: int) -> str:
     except OSError:
         return create_directory(path, count + 1)
 
+file = 'imacs.ini'
 
-log_dir = os.path.expanduser("~/.imacs/logs")
+config = ConfigParser()
+config.read(file)
 
-# Checks if a Configuration Directory exists
-if "IMACS_LOG_DIR" in os.environ:
-    log_dir = os.environ["IMACS_LOG_DIR"]
+if 'logs' in config.sections() and 'location' in config['logs']:
+    log_dir = config['logs']['location']
+else:
+    log_dir = os.path.expanduser("~/.imacs/logs")
 
 timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 

--- a/radio/app/__init__.py
+++ b/radio/app/__init__.py
@@ -1,16 +1,72 @@
 import logging
+import os
+import sys
+from datetime import datetime
 
 from flask import Flask
 from flask_socketio import SocketIO
 
-logging.basicConfig(level=logging.DEBUG)
 
-logger = logging.getLogger("fgcs")
-logger.setLevel(logging.DEBUG)
+def create_directory(path: str, count: int) -> str:
+    """
+    Recursively calls itself until it reaches a un-used directory name
 
+    Args:
+        - path: a string value of the folder name
+        - count: the number of calls of the recursion
+    Returns:
+        a string with the un-used directory name
+
+    """
+    try:
+        subdir_name = path
+        if count != 0:
+            subdir_name = f"{path}-{count}"
+            os.makedirs(subdir_name)
+        else:
+            os.makedirs(path)
+        return subdir_name
+    except OSError:
+        return create_directory(path, count + 1)
+
+
+log_dir = os.path.expanduser("~/.imacs/logs")
+
+# Checks if a Configuration Directory exists
+if "IMACS_LOG_DIR" in os.environ:
+    log_dir = os.environ["IMACS_LOG_DIR"]
+
+timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
+os.makedirs(log_dir, exist_ok=True)
+
+log_sub_dir = create_directory(f"{log_dir}/{timestamp}", 0)
+
+formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+stream_handler = logging.StreamHandler(sys.stdout)  # logs to stdout
+stream_handler.setFormatter(formatter)
+stream_handler.setLevel(logging.DEBUG)
+
+# Root Logs
+root_file = logging.FileHandler(f"{log_sub_dir}/root.log")
+root_logger = logging.getLogger()
+root_logger.addHandler(root_file)
+root_logger.addHandler(stream_handler)
+
+# FGCS Logs
+fgcs_file = logging.FileHandler(f"{log_sub_dir}/fgcs.log")
+fgcs_logger = logging.getLogger("fgcs")
+fgcs_logger.setLevel(logging.DEBUG)
+fgcs_logger.addHandler(fgcs_file)
+fgcs_logger.addHandler(stream_handler)
+
+# Flask Logs
+flask_file = logging.FileHandler(f"{log_sub_dir}/flask.log")
 flask_logger = logging.getLogger("werkzeug")
 flask_logger.setLevel(logging.INFO)
-
+flask_logger.addHandler(flask_file)
+flask_logger.addHandler(stream_handler)
 
 socketio = SocketIO(cors_allowed_origins="*", async_mode="threading")
 
@@ -30,6 +86,6 @@ def create_app(debug: bool = False) -> Flask:
 
     app.register_blueprint(endpoints)
 
-    logger.info("Initialising app")
+    fgcs_logger.info("Initialising app")
     socketio.init_app(app)
     return app

--- a/radio/app/endpoints/autopilot.py
+++ b/radio/app/endpoints/autopilot.py
@@ -1,7 +1,7 @@
 import time
 
 import app.droneStatus as droneStatus
-from app import logger, socketio
+from app import fgcs_logger, socketio
 from app.drone import Drone
 
 
@@ -42,7 +42,7 @@ def rebootAutopilot() -> None:
         else:
             break
     else:
-        logger.error("Could not reconnect to drone after 3 attempts.")
+        fgcs_logger.error("Could not reconnect to drone after 3 attempts.")
         socketio.emit(
             "reboot_autopilot",
             {
@@ -54,7 +54,7 @@ def rebootAutopilot() -> None:
 
     time.sleep(1)
     socketio.emit("connected_to_drone")
-    logger.info("Rebooted autopilot successfully.")
+    fgcs_logger.info("Rebooted autopilot successfully.")
     socketio.emit(
         "reboot_autopilot",
         {"success": True, "message": "Rebooted autopilot successfully."},

--- a/radio/app/endpoints/comPorts.py
+++ b/radio/app/endpoints/comPorts.py
@@ -5,7 +5,7 @@ from serial.tools import list_ports
 from typing_extensions import TypedDict
 
 import app.droneStatus as droneStatus
-from app import logger, socketio
+from app import fgcs_logger, socketio
 from app.drone import Drone
 from app.utils import droneConnectStatusCb, droneErrorCb, getComPortNames
 
@@ -82,7 +82,7 @@ def connectToDrone(data: ConnectionDataType) -> None:
             )
             return
 
-    logger.debug("Trying to connect to drone")
+    fgcs_logger.debug("Trying to connect to drone")
     baud = data.get("baud", 57600)
 
     if not isinstance(baud, int):
@@ -114,7 +114,7 @@ def connectToDrone(data: ConnectionDataType) -> None:
 
     # Sleeping for buffer time, if errors occur try changing back to 1 second
     time.sleep(0.2)
-    logger.debug("Created drone instance")
+    fgcs_logger.debug("Created drone instance")
     socketio.emit("connected_to_drone", {"aircraft_type": drone.aircraft_type})
 
 

--- a/radio/app/endpoints/connections.py
+++ b/radio/app/endpoints/connections.py
@@ -1,5 +1,5 @@
 import app.droneStatus as droneStatus
-from app import logger, socketio
+from app import fgcs_logger, socketio
 
 
 @socketio.on("connect")
@@ -7,7 +7,7 @@ def connection() -> None:
     """
     Simply handle a client connections
     """
-    logger.debug("Client connected!")
+    fgcs_logger.debug("Client connected!")
 
 
 @socketio.on("disconnect")
@@ -19,7 +19,7 @@ def disconnect() -> None:
         droneStatus.drone.close()
     droneStatus.drone = None
     droneStatus.state = None
-    logger.debug("Client disconnected!")
+    fgcs_logger.debug("Client disconnected!")
 
 
 @socketio.on("is_connected_to_drone")

--- a/radio/app/endpoints/flightMode.py
+++ b/radio/app/endpoints/flightMode.py
@@ -1,7 +1,7 @@
 from typing_extensions import TypedDict
 
 import app.droneStatus as droneStatus
-from app import logger, socketio
+from app import fgcs_logger, socketio
 from app.customTypes import SetFlightModeValueAndNumber
 from app.utils import droneErrorCb, notConnectedError
 
@@ -20,7 +20,7 @@ def getFlightModeConfig() -> None:
             "params_error",
             {"message": "You must be on the config screen to access the flight modes."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
@@ -48,7 +48,7 @@ def setFlightMode(data: SetFlightModeValueAndNumber) -> None:
             "params_error",
             {"message": "You must be on the config screen to access the flight modes."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
@@ -77,7 +77,7 @@ def refreshFlightModeData() -> None:
             "params_error",
             {"message": "You must be on the config screen to access the flight modes."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
@@ -109,7 +109,7 @@ def setCurrentFlightMode(data: SetCurrentFlightModeType) -> None:
                 "message": "You must be on the dashboard screen to set the current flight mode."
             },
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:

--- a/radio/app/endpoints/frames.py
+++ b/radio/app/endpoints/frames.py
@@ -1,4 +1,4 @@
-from app import logger, socketio
+from app import fgcs_logger, socketio
 import app.droneStatus as droneStatus
 from app.utils import notConnectedError
 
@@ -16,7 +16,7 @@ def getFrameDetails() -> None:
                 "message": "You must be on the motor test section of the config page to access the frame details"
             },
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:

--- a/radio/app/endpoints/gripper.py
+++ b/radio/app/endpoints/gripper.py
@@ -1,5 +1,5 @@
 import app.droneStatus as droneStatus
-from app import logger, socketio
+from app import fgcs_logger, socketio
 from app.utils import droneErrorCb
 
 
@@ -13,12 +13,12 @@ def gripperEnabled() -> None:
             "params_error",
             {"message": "You must be on the config screen to access the gripper."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
         droneErrorCb("You must be connected to the drone to access the gripper.")
-        logger.warning("Attempted to get gripper state when drone is None.")
+        fgcs_logger.warning("Attempted to get gripper state when drone is None.")
         return
     enabled = droneStatus.drone.gripperController.getEnabled()
     droneErrorCb(
@@ -39,12 +39,12 @@ def setGripper(action: str) -> None:
             "params_error",
             {"message": "You must be on the config screen to access the gripper."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
         droneErrorCb("You must be connected to the drone to access the gripper.")
-        logger.warning("Attempted to set gripper value when drone is None.")
+        fgcs_logger.warning("Attempted to set gripper value when drone is None.")
         return
 
     if action not in ["release", "grab"]:

--- a/radio/app/endpoints/mission.py
+++ b/radio/app/endpoints/mission.py
@@ -1,7 +1,7 @@
 from typing_extensions import TypedDict
 
 import app.droneStatus as droneStatus
-from app import logger, socketio
+from app import fgcs_logger, socketio
 from app.utils import notConnectedError
 
 
@@ -25,7 +25,7 @@ def getCurrentMission(data: CurrentMissionType) -> None:
                 "message": "You must be on the dashboard or missions screen to get the current mission."
             },
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
@@ -42,7 +42,7 @@ def getCurrentMission(data: CurrentMissionType) -> None:
                 "message": f"Invalid mission type. Must be 'mission', 'fence', or 'rally', got {mission_type}.",
             },
         )
-        logger.error(f"Could not get mission items for {mission_type} type.")
+        fgcs_logger.error(f"Could not get mission items for {mission_type} type.")
         return
 
     result = droneStatus.drone.missionController.getCurrentMission(
@@ -50,7 +50,7 @@ def getCurrentMission(data: CurrentMissionType) -> None:
     )
 
     if not result.get("success"):
-        logger.error(result.get("message"))
+        fgcs_logger.error(result.get("message"))
         socketio.emit("current_mission", result)
         return
 
@@ -72,7 +72,7 @@ def getCurrentMissionAll() -> None:
                 "message": "You must be on the dashboard or missions screen to get the current mission."
             },
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
@@ -100,7 +100,7 @@ def controlMission(data: ControlMissionType) -> None:
             "params_error",
             {"message": "You must be on the dashboard screen to control a mission."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
@@ -113,7 +113,7 @@ def controlMission(data: ControlMissionType) -> None:
             "params_error",
             {"message": f"Invalid action for controlling the mission, got {action}."},
         )
-        logger.debug(f"Invalid action for controlling the mission: {action}")
+        fgcs_logger.debug(f"Invalid action for controlling the mission: {action}")
         return
 
     if action == "start":

--- a/radio/app/endpoints/nav.py
+++ b/radio/app/endpoints/nav.py
@@ -1,7 +1,7 @@
 from typing_extensions import TypedDict
 
 import app.droneStatus as droneStatus
-from app import logger, socketio
+from app import fgcs_logger, socketio
 from app.utils import notConnectedError
 
 
@@ -27,7 +27,7 @@ def getHomePosition() -> None:
                 "message": "You must be on the dashboard or missions screen to get the home position."
             },
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
@@ -48,7 +48,7 @@ def takeoff(data: TakeoffDataType) -> None:
             "params_error",
             {"message": "You must be on the dashboard screen to takeoff."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
@@ -77,7 +77,7 @@ def land() -> None:
             "params_error",
             {"message": "You must be on the dashboard screen to land."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
@@ -98,7 +98,7 @@ def reposition(data: RepositionDataType) -> None:
             "params_error",
             {"message": "You must be on the dashboard screen to reposition."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:

--- a/radio/app/endpoints/params.py
+++ b/radio/app/endpoints/params.py
@@ -2,7 +2,7 @@ import time
 from typing import Any, List
 
 import app.droneStatus as droneStatus
-from app import logger, socketio
+from app import fgcs_logger, socketio
 
 
 @socketio.on("set_multiple_params")
@@ -19,7 +19,7 @@ def set_multiple_params(params_list: List[Any]) -> None:
             "params_error",
             {"message": "You must be on the params screen to save parameters."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:
@@ -44,7 +44,7 @@ def refresh_params() -> None:
             "params_error",
             {"message": "You must be on the params screen to refresh the parameters."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:

--- a/radio/app/endpoints/rc.py
+++ b/radio/app/endpoints/rc.py
@@ -1,5 +1,5 @@
 import app.droneStatus as droneStatus
-from app import logger, socketio
+from app import fgcs_logger, socketio
 from app.utils import notConnectedError
 
 
@@ -13,7 +13,7 @@ def getRcConfig() -> None:
             "params_error",
             {"message": "You must be on the config screen to access the RC config."},
         )
-        logger.debug(f"Current state: {droneStatus.state}")
+        fgcs_logger.debug(f"Current state: {droneStatus.state}")
         return
 
     if not droneStatus.drone:


### PR DESCRIPTION
I modified radio/app/__init__.py to:

-  Support a configurable log directory using the IMACS_LOG_DIR environment variable.
- If the variable is not set, logs default to ~/.imacs/logs.
- Save logs in a timestamped subdirectory (based on the time of execution).
- Split logs by type into separate files:
         root.log for general runtime logs.
         fgcs.log for IMACS backend logs.
          flask.log for Flask/Werkzeug logs.
- Continue sending logs to the console for real-time debugging.